### PR TITLE
Add setsize for darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 Pty is a Go package for using unix pseudo-terminals.
 
-(Note, there is only a Linux implementation. I'd appreciate a patch
-for other systems!)
-
 ## Install
 
     go get github.com/kr/pty

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,11 @@
+// Package pty provides functions for working with Unix terminals.
+package pty
+
+import (
+	"os"
+)
+
+// Opens a pty and its corresponding tty.
+func Open() (pty, tty *os.File, err error) {
+	return open()
+}

--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -10,8 +10,7 @@ import (
 // see ioccom.h
 const sys_IOCPARM_MASK = 0x1fff
 
-// Opens a pty and its corresponding tty.
-func Open() (pty, tty *os.File, err error) {
+func open() (pty, tty *os.File, err error) {
 	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
 	if err != nil {
 		return nil, nil, err

--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -67,3 +67,10 @@ func ioctl(fd, cmd, ptr uintptr) error {
 	}
 	return nil
 }
+
+func setsize(f *os.File, rows uint16, cols uint16) error {
+  var ws winsize
+  ws.ws_row   = rows
+  ws.ws_col   = cols
+	return ioctl(f.Fd(), syscall.TIOCSWINSZ, uintptr(unsafe.Pointer(&ws)))
+}

--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -69,8 +69,8 @@ func ioctl(fd, cmd, ptr uintptr) error {
 }
 
 func setsize(f *os.File, rows uint16, cols uint16) error {
-  var ws winsize
-  ws.ws_row   = rows
-  ws.ws_col   = cols
+	var ws winsize
+	ws.ws_row = rows
+	ws.ws_col = cols
 	return ioctl(f.Fd(), syscall.TIOCSWINSZ, uintptr(unsafe.Pointer(&ws)))
 }

--- a/pty_freebsd.go
+++ b/pty_freebsd.go
@@ -1,7 +1,6 @@
 package pty
 
 import (
-	"errors"
 	"os"
 	"strconv"
 	"syscall"
@@ -11,10 +10,6 @@ import (
 const (
 	sys_TIOCGPTN   = 0x4004740F
 	sys_TIOCSPTLCK = 0x40045431
-)
-
-var (
-	ErrUnsupported = errors.New("Unsupported")
 )
 
 func open() (pty, tty *os.File, err error) {

--- a/pty_freebsd.go
+++ b/pty_freebsd.go
@@ -1,7 +1,7 @@
 package pty
 
 import (
-  "errors"
+	"errors"
 	"os"
 	"strconv"
 	"syscall"
@@ -58,5 +58,5 @@ func ioctl(fd uintptr, cmd uintptr, data *int) error {
 }
 
 func setsize(f *os.File, rows uint16, cols uint16) error {
-  return ErrUnsupported
+	return ErrUnsupported
 }

--- a/pty_freebsd.go
+++ b/pty_freebsd.go
@@ -1,6 +1,7 @@
 package pty
 
 import (
+  "errors"
 	"os"
 	"strconv"
 	"syscall"
@@ -10,6 +11,10 @@ import (
 const (
 	sys_TIOCGPTN   = 0x4004740F
 	sys_TIOCSPTLCK = 0x40045431
+)
+
+var (
+	ErrUnsupported = errors.New("Unsupported")
 )
 
 func open() (pty, tty *os.File, err error) {
@@ -50,4 +55,8 @@ func ioctl(fd uintptr, cmd uintptr, data *int) error {
 		return syscall.ENOTTY
 	}
 	return nil
+}
+
+func setsize(f *os.File, rows uint16, cols uint16) error {
+  return ErrUnsupported
 }

--- a/pty_linux.go
+++ b/pty_linux.go
@@ -1,7 +1,6 @@
 package pty
 
 import (
-	"errors"
 	"os"
 	"strconv"
 	"syscall"
@@ -11,10 +10,6 @@ import (
 const (
 	sys_TIOCGPTN   = 0x80045430
 	sys_TIOCSPTLCK = 0x40045431
-)
-
-var (
-	ErrUnsupported = errors.New("Unsupported")
 )
 
 func open() (pty, tty *os.File, err error) {

--- a/pty_linux.go
+++ b/pty_linux.go
@@ -12,8 +12,7 @@ const (
 	sys_TIOCSPTLCK = 0x40045431
 )
 
-// Opens a pty and its corresponding tty.
-func Open() (pty, tty *os.File, err error) {
+func open() (pty, tty *os.File, err error) {
 	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
 	if err != nil {
 		return nil, nil, err

--- a/pty_linux.go
+++ b/pty_linux.go
@@ -28,7 +28,7 @@ func open() (pty, tty *os.File, err error) {
 		return nil, nil, err
 	}
 
-	t, err := os.OpenFile(sname, os.O_RDWR, 0)
+	t, err := os.OpenFile(sname, os.O_RDWR|syscall.O_NOCTTY, 0)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pty_linux.go
+++ b/pty_linux.go
@@ -1,6 +1,7 @@
 package pty
 
 import (
+	"errors"
 	"os"
 	"strconv"
 	"syscall"
@@ -10,6 +11,10 @@ import (
 const (
 	sys_TIOCGPTN   = 0x80045430
 	sys_TIOCSPTLCK = 0x40045431
+)
+
+var (
+	ErrUnsupported = errors.New("Unsupported")
 )
 
 func open() (pty, tty *os.File, err error) {
@@ -60,4 +65,8 @@ func ioctl(fd uintptr, cmd uintptr, data *int) error {
 		return syscall.ENOTTY
 	}
 	return nil
+}
+
+func setsize(f *os.File, rows uint16, cols uint16) error {
+  return ErrUnsupported
 }

--- a/pty_linux.go
+++ b/pty_linux.go
@@ -68,5 +68,5 @@ func ioctl(fd uintptr, cmd uintptr, data *int) error {
 }
 
 func setsize(f *os.File, rows uint16, cols uint16) error {
-  return ErrUnsupported
+	return ErrUnsupported
 }

--- a/pty_unsupported.go
+++ b/pty_unsupported.go
@@ -30,3 +30,7 @@ func unlockpt(f *os.File) error {
 func ioctl(fd, cmd, ptr uintptr) error {
 	return ErrUnsupported
 }
+
+func setsize(f *os.File, rows uint16, cols uint16) error {
+	return ErrUnsupported
+}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,35 @@
+package pty
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// Getsize returns the number of rows (lines) and cols (positions
+// in each line) in terminal t.
+func Getsize(t *os.File) (rows, cols int, err error) {
+	var ws winsize
+	err = windowrect(&ws, t.Fd())
+	return int(ws.ws_row), int(ws.ws_col), err
+}
+
+type winsize struct {
+	ws_row    uint16
+	ws_col    uint16
+	ws_xpixel uint16
+	ws_ypixel uint16
+}
+
+func windowrect(ws *winsize, fd uintptr) error {
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		fd,
+		syscall.TIOCGWINSZ,
+		uintptr(unsafe.Pointer(ws)),
+	)
+	if errno != 0 {
+		return syscall.Errno(errno)
+	}
+	return nil
+}

--- a/util.go
+++ b/util.go
@@ -15,7 +15,7 @@ func Getsize(t *os.File) (rows, cols int, err error) {
 }
 
 func Setsize(t *os.File, rows uint16, cols uint16) error {
-  return setsize(t, rows, cols)
+	return setsize(t, rows, cols)
 }
 
 type winsize struct {

--- a/util.go
+++ b/util.go
@@ -37,11 +37,3 @@ func windowrect(ws *winsize, fd uintptr) error {
 	}
 	return nil
 }
-
-func setsize(f *os.File, rows uint16, cols uint16) error {
-  var ws winsize
-  ws.ws_row   = rows
-  ws.ws_col   = cols
-	return ioctl(f.Fd(), syscall.TIOCSWINSZ, uintptr(unsafe.Pointer(&ws)))
-}
-


### PR DESCRIPTION
Uses `TIOCSWINSZ` to set the rows/cols of a pseudo terminal.  Should work on both mac/linux, but only confirmed on a mac.

I'm new to Go, feedback/criticism is welcome.
