### PR TITLE
run: don't override supplied SysProcAttr

### DIFF
--- a/run.go
+++ b/run.go
@@ -18,7 +18,11 @@ func Start(c *exec.Cmd) (pty *os.File, err error) {
 	c.Stdout = tty
 	c.Stdin = tty
 	c.Stderr = tty
-	c.SysProcAttr = &syscall.SysProcAttr{Setctty: true, Setsid: true}
+	if c.SysProcAttr == nil {
+		c.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	c.SysProcAttr.Setctty = true
+	c.SysProcAttr.Setsid = true
 	err = c.Start()
 	if err != nil {
 		pty.Close()


### PR DESCRIPTION
If we're passed an exec.Cmd that already has a configured SysProcAttr,
Start was obliterating it by overwriting it with a new struct in order
to set `Setctty` and `Setsid`. Instead, just adjust the parameters that
we need.