### PR TITLE
linux mips64 support with go1.6

### DIFF
--- a/ztypes_mips64.go
+++ b/ztypes_mips64.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/ztypes_mips64le.go
+++ b/ztypes_mips64le.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)


### PR DESCRIPTION
mips64/mips64le ztypes made with

GOOS=linux GOARCH=mips64 ./mktypes.bash
GOOS=linux GOARCH=mips64le ./mktypes.bash
