### PR TITLE
Prevent golang to set the non-block flag on ptmx open to avoid 100% CPU reads

### DIFF
--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -8,10 +8,11 @@ import (
 )
 
 func open() (pty, tty *os.File, err error) {
-	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	pFD, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|syscall.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, nil, err
 	}
+	p := os.NewFile(uintptr(pFD), "/dev/ptmx")
 
 	sname, err := ptsname(p)
 	if err != nil {


### PR DESCRIPTION
Solves #52 