### PR TITLE
add openbsd/amd64 support

### DIFF
--- a/mktypes.bash
+++ b/mktypes.bash
@@ -13,7 +13,7 @@ GODEFS="go tool cgo -godefs"
 $GODEFS types.go |gofmt > ztypes_$GOARCH.go
 
 case $GOOS in
-freebsd|dragonfly)
+freebsd|dragonfly|openbsd)
 	$GODEFS types_$GOOS.go |gofmt > ztypes_$GOOSARCH.go
 	;;
 esac

--- a/pty_openbsd.go
+++ b/pty_openbsd.go
@@ -1,0 +1,35 @@
+package pty
+
+import (
+	"C"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func open() (pty, tty *os.File, err error) {
+	/*
+	 * from ptm(4):
+	 * The PTMGET command allocates a free pseudo terminal, changes its
+	 * ownership to the caller, revokes the access privileges for all previous
+	 * users, opens the file descriptors for the master and slave devices and
+	 * returns them to the caller in struct ptmget.
+	 */
+
+	p, err := os.OpenFile("/dev/ptm", os.O_RDWR|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer p.Close()
+
+	var ptm ptmget
+	err = ioctl(p.Fd(), uintptr(ioctl_PTMGET), uintptr(unsafe.Pointer(&ptm)))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pty = os.NewFile(uintptr(ptm.Cfd), "/dev/ptm")
+	tty = os.NewFile(uintptr(ptm.Sfd), "/dev/ptm")
+
+	return pty, tty, nil
+}

--- a/pty_openbsd.go
+++ b/pty_openbsd.go
@@ -1,7 +1,6 @@
 package pty
 
 import (
-	"C"
 	"os"
 	"syscall"
 	"unsafe"
@@ -23,8 +22,7 @@ func open() (pty, tty *os.File, err error) {
 	defer p.Close()
 
 	var ptm ptmget
-	err = ioctl(p.Fd(), uintptr(ioctl_PTMGET), uintptr(unsafe.Pointer(&ptm)))
-	if err != nil {
+	if err := ioctl(p.Fd(), uintptr(ioctl_PTMGET), uintptr(unsafe.Pointer(&ptm))); err != nil {
 		return nil, nil, err
 	}
 

--- a/pty_unsupported.go
+++ b/pty_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!freebsd,!dragonfly
+// +build !linux,!darwin,!freebsd,!dragonfly,!openbsd
 
 package pty
 

--- a/types_openbsd.go
+++ b/types_openbsd.go
@@ -1,0 +1,13 @@
+// +build ignore
+
+package pty
+
+/*
+#include <stdlib.h>
+#include <sys/tty.h>
+*/
+import "C"
+
+type ptmget C.struct_ptmget
+
+var ioctl_PTMGET = C.PTMGET

--- a/types_openbsd.go
+++ b/types_openbsd.go
@@ -3,6 +3,7 @@
 package pty
 
 /*
+#include <sys/time.h>
 #include <stdlib.h>
 #include <sys/tty.h>
 */

--- a/ztypes_openbsd_amd64.go
+++ b/ztypes_openbsd_amd64.go
@@ -1,0 +1,13 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_openbsd.go
+
+package pty
+
+type ptmget struct {
+	Cfd int32
+	Sfd int32
+	Cn  [16]int8
+	Sn  [16]int8
+}
+
+var ioctl_PTMGET = 0x40287401


### PR DESCRIPTION
Minor change based on #48 
 
Fixes the cross compile (remove "C" import from pty_openbsd.go)
Fixes ztype generation on openbsd 6.2 (Add sys/time.h include to types_openbsd.go)

Tested on openbsd 6.2 amd64
  
Getsize / Setsize also work.