### PR TITLE
Add support for OpenBSD 386.  Prevents compile errors.

### DIFF
--- a/ztypes_openbsd_386.go
+++ b/ztypes_openbsd_386.go
@@ -1,0 +1,13 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_openbsd.go
+
+package pty
+
+type ptmget struct {
+	Cfd	int32
+	Sfd	int32
+	Cn	[16]int8
+	Sn	[16]int8
+}
+
+var ioctl_PTMGET = 0x40287401


### PR DESCRIPTION
Created file from a OpenBSD 386 installation and:

go tool cgo -godefs types_openbsd.go > ztypes_openbsd_386.go

Will resolve problems over here:

https://github.com/buildkite/agent/pull/785