### PR TITLE
Don't set Stdin/Stdout/Stderr if already set

### DIFF
--- a/run.go
+++ b/run.go
@@ -33,9 +33,13 @@ func StartWithSize(c *exec.Cmd, sz *Winsize) (pty *os.File, err error) {
 			return nil, err
 		}
 	}
-	c.Stdout = tty
+	if c.Stdout == nil {
+		c.Stdout = tty
+	}
+	if c.Stderr == nil {
+		c.Stderr = tty
+	}
 	c.Stdin = tty
-	c.Stderr = tty
 	if c.SysProcAttr == nil {
 		c.SysProcAttr = &syscall.SysProcAttr{}
 	}

--- a/run.go
+++ b/run.go
@@ -39,7 +39,9 @@ func StartWithSize(c *exec.Cmd, sz *Winsize) (pty *os.File, err error) {
 	if c.Stderr == nil {
 		c.Stderr = tty
 	}
-	c.Stdin = tty
+	if c.Stdin == nil {
+		c.Stdin = tty
+	}
 	if c.SysProcAttr == nil {
 		c.SysProcAttr = &syscall.SysProcAttr{}
 	}


### PR DESCRIPTION
As a continue of: https://github.com/kr/pty/pull/70 (it was required to make a fix, so I forked and recreated the Pull Request).

In my case it was required to use custom Stdout (that's why I would like to see the patch merged).