### PR TITLE
Set Ctty in SysProcAttr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/kr/pty
+
+go 1.12

--- a/run.go
+++ b/run.go
@@ -47,6 +47,7 @@ func StartWithSize(c *exec.Cmd, sz *Winsize) (pty *os.File, err error) {
 	}
 	c.SysProcAttr.Setctty = true
 	c.SysProcAttr.Setsid = true
+	c.SysProcAttr.Ctty = int(tty.Fd())
 	err = c.Start()
 	if err != nil {
 		pty.Close()


### PR DESCRIPTION
Without this change, the controlling TTY is not set, so processes like less cannot have their stdin redirected. This was partially fixed many years ago, but it seemed the last piece of the puzzle was never put in.